### PR TITLE
Fast app by id

### DIFF
--- a/src/main/java/com/bitplane/xt/DefaultImarisService.java
+++ b/src/main/java/com/bitplane/xt/DefaultImarisService.java
@@ -36,6 +36,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import net.imagej.DatasetService;
 import org.scijava.Priority;
 import org.scijava.plugin.Parameter;
 import org.scijava.plugin.Plugin;
@@ -53,6 +54,9 @@ import static Imaris.IApplicationPrxHelper.checkedCast;
 @Plugin( type = Service.class, priority = Priority.LOW )
 public class DefaultImarisService extends AbstractService implements ImarisService
 {
+	@Parameter
+	private DatasetService datasetService;
+
 	@Override
 	public synchronized void disconnect()
 	{

--- a/src/main/java/com/bitplane/xt/DefaultImarisService.java
+++ b/src/main/java/com/bitplane/xt/DefaultImarisService.java
@@ -115,27 +115,30 @@ public class DefaultImarisService extends AbstractService implements ImarisServi
 		{
 			final int applicationId = server.GetObjectID( i );
 			ImarisApplication app = existing.get( applicationId );
-			if ( app != null )
+			if ( app == null )
+			{
+				tryAddApplication( applicationId, server );
+			}
+			else
 			{
 				apps.add( app );
 				idToApp.put( applicationId, app );
-			}
-			else {
-				tryAddApplication( applicationId, server );
 			}
 		}
 	}
 
 	private void tryAddApplication( int applicationId, IServerPrx server )
 	{
-		try {
+		try
+		{
 			final IApplicationPrx iApplicationPrx = checkedCast( server.GetObject( applicationId ) );
 			ImarisApplication app = new DefaultImarisApplication( iApplicationPrx, applicationId );
 			context().inject( app );
 			apps.add( app );
 			idToApp.put( applicationId, app );
 		}
-		catch (Exception e) {
+		catch (Exception e)
+		{
 			e.printStackTrace();
 		}
 	}


### PR DESCRIPTION
Requesting an application by id do not refresh the entire list of applications, but tries to connect to the requested application only. Refresh applications now continues if a checked cast fails.